### PR TITLE
Removes grey box from "Music"

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -60,6 +60,14 @@ typedef enum {
 	return nil;
 }
 %end
+
+%hook MPUEmptyNowPlayingView
+
+- (void)setBackgroundColor:(UIColor *)arg1 {
+	%orig([UIColor clearColor]);
+}
+
+%end
 %end
 
 %group polus


### PR DESCRIPTION
The hook removes the grey box from the "Music" section of the Control Center.